### PR TITLE
Fix for AFIT token if there's no trading history.

### DIFF
--- a/src/common/steem-engine.ts
+++ b/src/common/steem-engine.ts
@@ -65,7 +65,7 @@ export async function loadTokens(): Promise<any[]> {
 
                         if (token.symbol == 'AFIT') {
                             const afit_data = await ssc.find('market', 'tradesHistory', { symbol: 'AFIT' }, 100, 0, [{ index: 'timestamp', descending: false }], false);
-                            token.volume = afit_data.reduce((t, v) => t += parseFloat(v.price) * parseFloat(v.quantity), 0);
+                            token.volume = (afit_data) ? afit_data.reduce((t, v) => t += parseFloat(v.price) * parseFloat(v.quantity), 0) : 0;
                         }
                     }
 


### PR DESCRIPTION
Running the website locally against the test api causes issues for the AFIT token since there is no trading history for that token.