### PR TITLE
Sell orders in proper order, refactor exchange view

### DIFF
--- a/src/components/chart/chart.html
+++ b/src/components/chart/chart.html
@@ -32,6 +32,10 @@
     </div>
 
     <style>
+        .chart-container {
+            max-height: 400px;
+        }
+
         .chart-icon {
             padding: 6px 4px;
         }

--- a/src/components/chart/chart.ts
+++ b/src/components/chart/chart.ts
@@ -11,7 +11,9 @@ const DefaultChartOptions = {
         legend: {
             display: false
         },
-        steppedLine: true
+        steppedLine: true,
+        responsive: true,
+        maintainAspectRatio: false
     }
 };
 

--- a/src/routes/exchange/exchange.html
+++ b/src/routes/exchange/exchange.html
@@ -16,6 +16,9 @@
     </div>
     <div class="container-fluid h100-minus-header">
         <div class="row exchange-columns h100">
+            <div class="col-12">
+                <chart class="exchange-chart" data.bind="chartData" view-model.ref="chartRef"></chart>
+            </div>
             <div class="col-lg-3 col-md-12 col-sm-12">
                 <div class="exchange-header">
                     <h2>${'Sell Orders' & t}</h2>
@@ -33,10 +36,6 @@
             </div>
 
             <div class="col-lg-6 col-md-12 col-sm-12 chart-col">
-                <chart class="exchange-chart" data.bind="chartData" view-model.ref="chartRef"></chart>
-
-                <hr />
-
                 <div class="row">
                     <div class="col-md-6">
                         <balances data.bind="data"

--- a/src/routes/exchange/exchange.module.css
+++ b/src/routes/exchange/exchange.module.css
@@ -39,8 +39,7 @@ tr td:last-child {
 .exchange-chart {
     background: #fff;
     display: block;
-    margin-bottom: 20px;
-    margin-top: 15px;
+    margin-bottom: 50px;
 }
 
 .balances-heading {

--- a/src/routes/exchange/exchange.ts
+++ b/src/routes/exchange/exchange.ts
@@ -21,7 +21,6 @@ import { WithdrawModal } from 'modals/withdraw';
 import { MarketOrderModal } from 'modals/market-order';
 
 import { DialogService } from 'aurelia-dialog';
-import { percentageOf } from 'common/functions';
 import { loadBuyBook, loadSellBook, exchangeData } from 'store/actions';
 import { dispatchify, Store } from 'aurelia-store';
 import { Subscription as StateSubscription } from 'rxjs';
@@ -173,6 +172,9 @@ export class Exchange {
                 sellOrderDataset.push(sellOrderCurrentVolume);
             }
         });
+
+        sellOrderLabels.reverse();
+        sellOrderDataset.reverse();
 
         this.sellBook.reverse();
 


### PR DESCRIPTION
- Sell orders in depth chart are correct
- Moves chart into its own single line on the exchange