### PR TITLE
Refactor tokens screen and increase buy/sell book size

### DIFF
--- a/src/common/firebase.ts
+++ b/src/common/firebase.ts
@@ -1,5 +1,8 @@
+import { ISettings } from './../store/state';
+import { environment } from 'environment';
 import { login, setAccount, logout } from 'store/actions';
 import { dispatchify } from 'aurelia-store';
+
 import firebase from 'firebase/app';
 import 'firebase/auth';
 import 'firebase/firestore';
@@ -34,4 +37,24 @@ export async function authStateChanged() {
             }
         });
     });
+}
+
+export async function getFirebaseUser(username: string) {
+    const doc = await firebase
+        .firestore()
+        .collection('users')
+        .doc(username)
+        .get();
+
+    return doc.exists ? doc.data() : null;
+}
+
+export async function loadSiteSettings() {
+    const settings = await firebase
+        .firestore()
+        .collection('admin')
+        .doc('settings')
+        .get();
+
+    return settings.exists ? { ...environment, ...settings.data() } : { ...environment } as ISettings;
 }

--- a/src/common/steem-engine.ts
+++ b/src/common/steem-engine.ts
@@ -89,9 +89,9 @@ export function parseTokens(data: any, settings: State['settings']): State {
     return tokens;
 }
 
-export async function loadTokens(limit = 1000, offset = 0): Promise<any[]> {
+export async function loadTokens(symbols = [], limit = 1000, offset = 0): Promise<any[]> {
     const callQl = await query(`query {
-        tokens(limit: ${limit}, offset: ${offset}) {
+        tokens(limit: ${limit}, offset: ${offset}, symbols: ${JSON.stringify(symbols)}) {
             issuer,
             symbol,
             name,

--- a/src/common/steem-engine.ts
+++ b/src/common/steem-engine.ts
@@ -91,7 +91,7 @@ export function parseTokens(data: any, settings: State['settings']): State {
 
 export async function loadTokens(symbols = [], limit = 1000, offset = 0): Promise<any[]> {
     const callQl = await query(`query {
-        tokens(limit: ${limit}, offset: ${offset}, symbols: ${JSON.stringify(symbols)}) {
+        tokens(resultLimit: ${limit}, resultOffset: ${offset}, symbols: ${JSON.stringify(symbols)}) {
             issuer,
             symbol,
             name,
@@ -140,15 +140,10 @@ export async function loadTokens(symbols = [], limit = 1000, offset = 0): Promis
     if (steempBalance && steempBalance.balance) {
         const token = finalTokens.find(t => t.symbol === 'STEEMP');
 
-        token.supply -= parseFloat(steempBalance.balance);
-        (token as any).circulatingSupply -= parseFloat(steempBalance.balance);
-    }
-
-    if (steempBalance && steempBalance.balance) {
-        const token = finalTokens.find(t => t.symbol === 'STEEMP');
-
-        token.supply -= parseFloat(steempBalance.balance);
-        (token as any).circulatingSupply -= parseFloat(steempBalance.balance);
+        if (token) {
+            token.supply -= parseFloat(steempBalance.balance);
+            (token as any).circulatingSupply -= parseFloat(steempBalance.balance);
+        }
     }
 
     return finalTokens;

--- a/src/common/steem-engine.ts
+++ b/src/common/steem-engine.ts
@@ -91,7 +91,7 @@ export function parseTokens(data: any, settings: State['settings']): State {
 
 export async function loadTokens(symbols = [], limit = 1000, offset = 0): Promise<any[]> {
     const callQl = await query(`query {
-        tokens(resultLimit: ${limit}, resultOffset: ${offset}, symbols: ${JSON.stringify(symbols)}) {
+        tokens(limit: ${limit}, offset: ${offset}, symbols: ${JSON.stringify(symbols)}) {
             issuer,
             symbol,
             name,

--- a/src/routes/tokens.html
+++ b/src/routes/tokens.html
@@ -24,7 +24,7 @@
     <div class="container main-container">
         <div class="row">
             <div class="col-12">
-                <button if.bind="tab === 'other'" type="button" click.delegate="loadMoreTokens()">${'Load More'}</button>
+                <button if.bind="tab === 'other'" type="button" click.delegate="loadMoreTokens()" if.bind="!state.tokensLoaded">${'Load More'}</button>
                 <table class="table table-dark" ref="tokenTable">
                     <thead>
                         <tr>

--- a/src/routes/tokens.html
+++ b/src/routes/tokens.html
@@ -11,13 +11,22 @@
                     <a class="button btn btn-primary" route-href="route: createToken;">${'Create Token' & t}</a>
                 </div>
             </div>
+
+            <nav class="nav tabs mt-3">
+                <a class="nav-link tabs__tab ${tab === 'pegged' ? 'active' : ''}" href="javascript:void(0);">Pegged Tokens</a>
+                <a class="nav-link tabs__tab ${tab === 'supported' ? 'active' : ''}" href="javascript:void(0);">Supported Tokens</a>
+                <a class="nav-link tabs__tab ${tab === 'popular' ? 'active' : ''}" href="javascript:void(0);">Popular Tokens</a>
+                <a class="nav-link tabs__tab ${tab === 'other' ? 'active' : ''}" href="javascript:void(0);">Other Tokens</a>
+            </nav>
         </div>
     </header>
 
     <div class="container main-container">
         <div class="row">
             <div class="col-12">
-                <div class="tabs"></div>
+                <div class="tabs">
+                        <a class="nav-link tabs__tab">Core Tokens</a>
+                </div>
             </div>
         </div>
 

--- a/src/routes/tokens.html
+++ b/src/routes/tokens.html
@@ -24,7 +24,7 @@
     <div class="container main-container">
         <div class="row">
             <div class="col-12">
-                <button if.bind="tab === 'other'" type="button" click.delegate="loadMoreTokens()" if.bind="!state.tokensLoaded">${'Load More'}</button>
+                <button if.bind="tab === 'other' && !state.tokensLoaded" type="button" class="btn btn-md btn-primary" click.delegate="loadMoreTokens()">${'Load More'}</button>
                 <table class="table table-dark" ref="tokenTable">
                     <thead>
                         <tr>
@@ -96,6 +96,7 @@
                         </tr>
                     </tbody>
                 </table>
+                <button if.bind="tab === 'other' && !state.tokensLoaded" type="button" class="btn btn-md btn-primary" click.delegate="loadMoreTokens()">${'Load More'}</button>
             </div>
         </div>
     </div>

--- a/src/routes/tokens.html
+++ b/src/routes/tokens.html
@@ -1,4 +1,6 @@
 <template>
+    <loader loading.bind="loading"></loader>
+
     <header class="main-header">
         <div class="container-fluid main-container d-flex flex-column justify-content-end">
             <div class="row">
@@ -13,10 +15,8 @@
             </div>
 
             <nav class="nav tabs mt-3">
-                <a class="nav-link tabs__tab ${tab === 'pegged' ? 'active' : ''}" href="javascript:void(0);">Pegged Tokens</a>
-                <a class="nav-link tabs__tab ${tab === 'supported' ? 'active' : ''}" href="javascript:void(0);">Supported Tokens</a>
-                <a class="nav-link tabs__tab ${tab === 'popular' ? 'active' : ''}" href="javascript:void(0);">Popular Tokens</a>
-                <a class="nav-link tabs__tab ${tab === 'other' ? 'active' : ''}" href="javascript:void(0);">Other Tokens</a>
+                <a class="nav-link tabs__tab ${tab === 'pegged' ? 'active' : ''}" href="javascript:void(0);" click.delegate="tab = 'pegged'">Pegged Tokens</a>
+                <a class="nav-link tabs__tab ${tab === 'other' ? 'active' : ''}" href="javascript:void(0);" click.delegate="tab = 'other'">Other Tokens</a>
             </nav>
         </div>
     </header>
@@ -24,14 +24,7 @@
     <div class="container main-container">
         <div class="row">
             <div class="col-12">
-                <div class="tabs">
-                        <a class="nav-link tabs__tab">Core Tokens</a>
-                </div>
-            </div>
-        </div>
-
-        <div class="row">
-            <div class="col-12">
+                <button if.bind="tab === 'other'" type="button" click.delegate="loadMoreTokens()">${'Load More'}</button>
                 <table class="table table-dark" ref="tokenTable">
                     <thead>
                         <tr>

--- a/src/routes/tokens.ts
+++ b/src/routes/tokens.ts
@@ -19,12 +19,14 @@ export class Tokens {
     private state: State;
     private loading = false;
 
-    private currentLimit = 25;
+    private datatable;
+
+    private currentLimit = 50;
     private currentOffset = 0;
 
     @observable() private tab = 'pegged';
 
-    constructor(private se: SteemEngine, private taskQueue: TaskQueue, private dialogService: DialogService) {}
+    constructor(private se: SteemEngine, private taskQueue: TaskQueue, private dialogService: DialogService) { }
 
     async canActivate() {
         await dispatchify(loadTokenSymbols)(['BCHP', 'BTCP', 'DOGEP', 'STEEMP', 'BRIDGEBTCP', 'BTSCNYP', 'BTSP', 'LTCP', 'PEOSP', 'SWIFTP', 'TLOSP', 'WEKUP'], 50, 0);
@@ -37,9 +39,12 @@ export class Tokens {
     async loadMoreTokens() {
         this.currentOffset++;
 
+        const limit = this.currentOffset * this.currentLimit;
+        const offset = (this.currentOffset + 1) * this.currentLimit;
+
         this.loading = true;
 
-        await dispatchify(loadTokensList)(this.currentLimit, this.currentOffset);
+        await dispatchify(loadTokensList)(limit, offset);
 
         this.loading = false;
     }
@@ -71,8 +76,12 @@ export class Tokens {
     }
 
     attached() {
+        this.applyDatatable();
+    }
+
+    applyDatatable() {
         // @ts-ignore
-        $(this.tokenTable).DataTable({
+        this.datatable = $(this.tokenTable).DataTable({
             order: [],
             columnDefs: [
                 {
@@ -80,6 +89,7 @@ export class Tokens {
                     orderable: false,
                 },
             ],
+            destroy: true,
             bInfo: false,
             paging: false,
             searching: false,

--- a/src/routes/tokens.ts
+++ b/src/routes/tokens.ts
@@ -34,10 +34,14 @@ export class Tokens {
         await dispatchify(getCurrentFirebaseUser)();
     }
 
-    loadMoreTokens() {
+    async loadMoreTokens() {
         this.currentOffset++;
-        console.log(this.currentOffset);
-        dispatchify(loadTokensList)(this.currentLimit, this.currentOffset);
+
+        this.loading = true;
+
+        await dispatchify(loadTokensList)(this.currentLimit, this.currentOffset);
+
+        this.loading = false;
     }
 
     async tabChanged(tab) {

--- a/src/routes/tokens.ts
+++ b/src/routes/tokens.ts
@@ -17,11 +17,12 @@ export class Tokens {
     private styles = styles;
     private tokenTable: HTMLTableElement;
     private state: State;
+    private tab = 'pegged';
 
     constructor(private se: SteemEngine, private taskQueue: TaskQueue, private dialogService: DialogService) {}
 
     async canActivate() {
-        await dispatchify(loadTokensList)();
+        await dispatchify(loadTokensList)(['BCHP', 'BTCP', 'DOGEP', 'STEEMP', 'BRIDGEBTCP', 'BTSCNYP', 'BTSP', 'LTCP', 'PEOSP', 'SWIFTP', 'TLOSP', 'WEKUP']);
     }
 
     async activate() {

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -251,7 +251,12 @@ export async function loadTokensList(state: State, limit = 50, offset = 0): Prom
 
     try {
         const tokens: IToken[] = await loadTokens([], limit, offset);
-        newState.tokens = [...tokens, ...newState.tokens];
+        if (tokens.length) {
+            newState.tokensLoaded = false;
+            newState.tokens = [...tokens, ...newState.tokens];
+        } else {
+            newState.tokensLoaded = true;
+        }
     } catch (e) {
         log.error(e);
     }

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -251,6 +251,7 @@ export async function loadTokensList(state: State, limit = 50, offset = 0): Prom
 
     try {
         const tokens: IToken[] = await loadTokens([], limit, offset);
+        
         if (tokens.length) {
             newState.tokensLoaded = false;
             newState.tokens = [...tokens, ...newState.tokens];

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -108,10 +108,10 @@ export async function getCurrentFirebaseUser(state: State): Promise<State> {
             if (newState?.firebaseUser?.favourites) {
                 newState.account.balances.map((token: any) => {
                     if (newState.firebaseUser.favourites.includes(token.symbol)) {
-                        token.isFavourite = true;
-                    } else {
-                        token.isFavourite = false;
-                    }
+                token.isFavourite = true;
+            } else {
+                token.isFavourite = false;
+            }
 
                     return token;
                 });
@@ -246,11 +246,24 @@ export async function loadTradeHistory(state: State, symbol: string, account: st
     return newState;
 }
 
-export async function loadTokensList(state: State, symbols = []): Promise<State> {
+export async function loadTokensList(state: State, limit = 50, offset = 0): Promise<State> {
     const newState = { ...state };
 
     try {
-        newState.tokens = await loadTokens(symbols);
+        const tokens: IToken[] = await loadTokens([], limit, offset);
+        newState.tokens = [...tokens, ...newState.tokens];
+    } catch (e) {
+        log.error(e);
+    }
+
+    return newState;
+}
+
+export async function loadTokenSymbols(state: State, symbols = [], limit = 50, offset = 0): Promise<State> {
+    const newState = { ...state };
+
+    try {
+        newState.tokens = await loadTokens(symbols, limit, offset);
     } catch (e) {
         log.error(e);
     }
@@ -531,6 +544,7 @@ store.registerAction('setTokens', setTokens);
 store.registerAction('getCurrentFirebaseUser', getCurrentFirebaseUser);
 store.registerAction('loadAccountBalances', loadAccountBalances);
 store.registerAction('loadTokensList', loadTokensList);
+store.registerAction('loadTokenSymbols', loadTokenSymbols);
 store.registerAction('loadBuyBook', loadBuyBook);
 store.registerAction('loadSellBook', loadSellBook);
 store.registerAction('loadTradeHistory', loadTradeHistory);

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -242,11 +242,11 @@ export async function loadTradeHistory(state: State, symbol: string, account: st
     return newState;
 }
 
-export async function loadTokensList(state: State): Promise<State> {
+export async function loadTokensList(state: State, symbols = []): Promise<State> {
     const newState = { ...state };
 
     try {
-        newState.tokens = await loadTokens();
+        newState.tokens = await loadTokens(symbols);
     } catch (e) {
         log.error(e);
     }

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -67,6 +67,7 @@ export interface State {
     loggedIn: boolean;
     loading: boolean;
     tokens: IToken[];
+    tokensLoaded: boolean;
     buyBook: any[];
     sellBook: any[];
     tradeHistory: any[];
@@ -115,5 +116,6 @@ export const initialState: State = {
     pendingWithdrawals: [],
     nft: null,
     nfts: [],
-    instances: []
+    instances: [],
+    tokensLoaded: false
 };


### PR DESCRIPTION
- Tokens screen now paginates results with support for results and offsets
- Optimised GraphQL API to return tokens data more efficiently
- Sell and buy book returns orders upwards of 1000