### PR TITLE
bugfix/missing_tokens_deposit

### DIFF
--- a/src/common/steem-engine.ts
+++ b/src/common/steem-engine.ts
@@ -108,16 +108,16 @@ export async function getFormattedCoinPairs() {
     for (const x of nonPeggedCoins) {
         // find pegged coin for each non-pegged coin
         const coinFound = pairs.find(y => y.from_coin_symbol === x.symbol);
-
+        
         if (coinFound) {
             const tp = {
                 name: x.display_name,
                 symbol: x.symbol,
                 pegged_token_symbol: coinFound.to_coin_symbol
             }
-
+            
             // check if the token exists
-            if (!tokenPairs.find(x => x.pegged_token_symbol == tp.pegged_token_symbol)) {
+            if (!tokenPairs.find(x => x.symbol == tp.symbol)) {
                 tokenPairs.push(tp);
             }
         }

--- a/src/modals/withdraw.html
+++ b/src/modals/withdraw.html
@@ -5,7 +5,7 @@
         <ux-dialog-header>
             <h2>${'Withdraw' & t}</h2>
         </ux-dialog-header>
-        <ux-dialog-body>
+        <ux-dialog-body class="withdrawDialogBody">
             <p class="note mb-4">
                 ${'There is a 1% fee on deposits and withdrawals' & t}                
             </p>
@@ -50,7 +50,7 @@
                             value.bind="amount"
                         />
                         <div class="input-group-append">
-                            ${token.symbol & t}
+                            ${token.pegged_token_symbol & t}
                         </div>
                         <div class="invalid-tooltip">
                             ${'errors:Please enter an amount greater than 0' &

--- a/src/styles/modal.css
+++ b/src/styles/modal.css
@@ -93,6 +93,10 @@ ux-dialog>ux-dialog-body {
     overflow: auto;
 }
 
+ux-dialog > ux-dialog-body.withdrawDialogBody {
+    max-height: 500px;
+}
+
 ux-dialog>ux-dialog-body a {
     color: #0048b3;
 }


### PR DESCRIPTION
- fix for missing tokens/pairs in deposit and withdraw popups
- increase max-length withdraw popup to show all information

Fix for issue: https://github.com/steem-engine-exchange/steem-engine-dex/issues/264