### PR TITLE
bugfix/nft_detail_timesold_fix

### DIFF
--- a/custom_typings/interfaces.d.ts
+++ b/custom_typings/interfaces.d.ts
@@ -298,6 +298,7 @@ interface INftSellBook {
     priceDec: number;
     priceSymbol: string;
     fee: number;
+    timestamp_string: string;
 }
 
 interface INftCounterparty {

--- a/src/routes/nfts/nft-detail/nft-detail.html
+++ b/src/routes/nfts/nft-detail/nft-detail.html
@@ -44,7 +44,7 @@
                                     <p>
                                         <span class="reviewer" style="font-weight: bolder; margin-right: 5px;"
                                             >Note:</span
-                                        >The prices displayed come from the last-order order on this token.
+                                        >The prices displayed come from the last order on this token.
                                     </p>
                                 </div>
                                 <hr />
@@ -100,7 +100,7 @@
                                 <div class="cat-card-body">
                                     <ul class="cat-card-items">
                                         <li class="cat-card-item flex-setting">
-                                            <a href="">${'Last Traded' & t}</a>
+                                            <a href="javascript:void(0);">${'Last Order' & t}</a>
 
                                             <span class="float-right">
                                                 <template if.bind="lastOrder"
@@ -116,8 +116,8 @@
                                             >
                                         </li>
                                         <li class="cat-card-item flex-setting" if.bind="lastOrder">
-                                            <a href="">${'Time Sold' & t}</a
-                                            ><span class="float-right">${lastOrder.timestamp}</span>
+                                            <a href="javascript:void(0);">${'Time Last Order' & t}</a
+                                            ><span class="float-right nftLastOrderDate">${lastOrder.timestamp_string}</span>
                                         </li>
                                         <li class="cat-card-item flex-setting" style="display: flex;">
                                             <span class="curr-price"

--- a/src/routes/nfts/nft-detail/nft-detail.module.css
+++ b/src/routes/nfts/nft-detail/nft-detail.module.css
@@ -184,3 +184,7 @@
 .info-wrapper {
     padding: 0 20px;
 }
+
+.nftLastOrderDate {
+    font-size: 13px;
+}

--- a/src/services/nft-service.ts
+++ b/src/services/nft-service.ts
@@ -5,6 +5,7 @@ import { steemConnectJson } from 'common/steem';
 import { customJson } from 'common/keychain';
 
 import { environment } from 'environment';
+import moment from 'moment';
 
 type NftFees = 'ENG' | 'PAL';
 type NftType = 'contract' | 'user';
@@ -98,6 +99,7 @@ export class NftService {
 
             for (const order of orders) {
                 order.price = parseFloat(order.price);
+                order.timestamp_string = moment.unix(order.timestamp / 1000).format('YYYY-MM-DD HH:mm');
             }
 
             return orders;


### PR DESCRIPTION
- Fix unix timestamp display nft-detail page
- Change labels: "Last traded" to "Last order" and "Time Sold" to "Time Last Order" to match correct values

Fix for issue: https://github.com/steem-engine-exchange/steem-engine-dex/issues/260